### PR TITLE
fix: remove dev x cache header

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -32,9 +32,6 @@ server {
   location /_next/static {
     proxy_cache STATIC;
     proxy_pass http://frontend;
-
-    # For testing cache - remove before deploying to production
-    add_header X-Cache-Status $upstream_cache_status;
   }
 
   location /static {
@@ -42,9 +39,6 @@ server {
     proxy_ignore_headers Cache-Control;
     proxy_cache_valid 60m;
     proxy_pass http://frontend;
-
-    # For testing cache - remove before deploying to production
-    add_header X-Cache-Status $upstream_cache_status;
   }
 
   location /api {


### PR DESCRIPTION
configure nginx to remove cache header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed testing cache headers from static content delivery settings to enhance performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->